### PR TITLE
[FIX] project: fixed domain to make archive records visible

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -895,7 +895,7 @@ class Task(models.Model):
             'search_default_project_id': self.env.context.get('project_id', self.subtask_project_id.id),
         })
         action['context'] = ctx
-        action['domain'] = [('id', 'child_of', self.id), ('id', '!=', self.id)]
+        action['domain'] = [('parent_id', '=', self.id), ('id', '!=', self.id)]
         return action
 
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

I have two subtask here namely Subtask1 & Subtask2, I archived the 'Subtask1', could not see that in img2.  


![sub tasks 3](https://user-images.githubusercontent.com/42735016/49327328-4bbe8500-f586-11e8-936e-120bb4947b8a.png)

Filtering of the Archived Subtask does not work as expected!

![sub tasks 2](https://user-images.githubusercontent.com/42735016/49327341-81636e00-f586-11e8-996f-806e45e441fe.png)



**Current behavior before PR:** 

Filtering Archived Subtasks does not seems to work because of the `child_of` parameter, which only fetches the active true records.

**Desired behavior after PR is merged:**

Instead the below domain will allow the user to filter the Archived Subtasks too!

`action['domain'] = [('parent_id', '=', self.id), ('id', '!=', self.id)]`




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
